### PR TITLE
[ITT-1044] Add retrying and a fallback for gpg key signing

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,28 @@ end.run_action(:install)
 
 # Per https://rvm.io/rvm/security, the keyserver is no longer keys.gnupg
 bash "import RVM pub key" do
-  code "gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
+  code <<-GPG
+    attempts=1
+    max_attempts=4
+    keyserver="keys.gnupg.net"
+
+    until [[ $attempts -eq $max_attempts ]]
+    do
+      echo "gpg attempt ${attempts}"
+      echo $keyserver
+
+      gpg --verbose --keyserver "hkp://${keyserver}" --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB·
+
+      [[ $? -eq 0 ]] && break
+      let "attempts+=1"
+
+      if [[ $attempts -eq 4 ]]
+      then
+        attempts=1
+        keyserver="keyserver.cns.vt.edu"
+      fi
+    done
+    GPG
   user "root"
   action :nothing
 end.run_action(:run)


### PR DESCRIPTION
[ITT-1044]

Output looks like this
```
~/Projects/chef-rvm(ITT-1044-update-keyserver*) » bash gpg-test.sh                                                                                                                                                                               146 ↵ mattsullivan@Matts-MBP-2
gpg attempt 1
keys.gnupg.net
gpg: keyserver receive failed: No name
gpg attempt 2
keys.gnupg.net
gpg: keyserver receive failed: No name
gpg attempt 3
keys.gnupg.net
gpg: keyserver receive failed: No name
gpg attempt 1
keyserver.cns.vt.edu
gpg: data source: http://keyserver.cns.vt.edu:11371
gpg: armor header: Version: SKS 1.1.6
gpg: armor header: Comment: Hostname: keyserver.cns.vt.edu
gpg: armor header: Version: SKS 1.1.6
gpg: armor header: Comment: Hostname: keyserver.cns.vt.edu
gpg: key 105BD0E739499BDB: number of dropped non-self-signatures: 8
gpg: pub  rsa4096/105BD0E739499BDB 2016-11-11  Piotr Kuczynski <piotr.kuczynski@gmail.com>
gpg: key 105BD0E739499BDB: "Piotr Kuczynski <piotr.kuczynski@gmail.com>" not changed
gpg: key 3804BB82D39DC0E3: number of dropped non-self-signatures: 108
gpg: pub  rsa4096/3804BB82D39DC0E3 2014-10-28  Michal Papis <michal.papis@toptal.com>
gpg: removing signature from key 3804BB82D39DC0E3 on user ID "Michal Papis (RVM signing) <mpapis@gmail.com>": signature superseded
gpg: removing signature from key 3804BB82D39DC0E3 on user ID "Michal Papis (RVM signing) <mpapis@gmail.com>": signature superseded
gpg: key 3804BB82D39DC0E3/E206C29FBF04FF17: removed multiple subkey binding
gpg: key 3804BB82D39DC0E3/E206C29FBF04FF17: removed multiple subkey binding
gpg: key 3804BB82D39DC0E3: "Michal Papis (RVM signing) <mpapis@gmail.com>" not changed
gpg: Total number processed: 2
gpg:              unchanged: 2
```

[ITT-1044]: https://getaroom.atlassian.net/browse/ITT-1044